### PR TITLE
Always initialize variable.

### DIFF
--- a/programs/datachan_serv.c
+++ b/programs/datachan_serv.c
@@ -419,7 +419,7 @@ main(int argc, char *argv[])
           int stream, reliable;
           int len;
           uint32_t timeout;
-          uint32_t flags;
+          uint32_t flags = 0;
 
           if (sscanf(inputline,"open %d %d:",&stream,&reliable) == 2)
           {


### PR DESCRIPTION
Some compilers complain about potentially uninitialized usage otherwise.